### PR TITLE
Add devcontainer and GitHub Actions CI (ROS Noetic)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+FROM ros:noetic-ros-base
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    python3-catkin-tools \
+    python3-rosdep \
+    ros-noetic-pcl-ros \
+    ros-noetic-cv-bridge \
+    ros-noetic-tf2-eigen \
+    ros-noetic-tf2-geometry-msgs \
+    libyaml-cpp-dev \
+    libboost-all-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN echo "source /opt/ros/noetic/setup.bash" >> /root/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "name": "hawkeye (ROS Noetic)",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "workspaceFolder": "/workspace/src/hawkeye",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/src/hawkeye,type=bind",
+  "postCreateCommand": "cd /workspace && rosdep update && rosdep install --from-paths src --ignore-src -r -y",
+  "postStartCommand": "source /opt/ros/noetic/setup.bash",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools",
+        "ms-vscode.cmake-tools",
+        "twxs.cmake"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "C_Cpp.default.includePath": [
+          "/opt/ros/noetic/include",
+          "${workspaceFolder}/include"
+        ]
+      }
+    }
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t hawkeye-dev .devcontainer/
+
+      - name: Build with catkin
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/workspace/src/hawkeye \
+            hawkeye-dev \
+            bash -c "
+              source /opt/ros/noetic/setup.bash && \
+              cd /workspace && \
+              catkin_make 2>&1
+            "


### PR DESCRIPTION
## Summary

- `.devcontainer/Dockerfile`: ROS Noetic ベースの開発コンテナ（pcl-ros, cv-bridge, tf2-geometry-msgs, yaml-cpp 等を含む）
- `.devcontainer/devcontainer.json`: VS Code devcontainer 設定
- `.github/workflows/build.yml`: PR・push 時に catkin_make でビルドを確認する CI

## 確認済み

ローカルで Docker ビルド → `catkin_make` が `[100%]` まで通ることを確認済み。