### PR TITLE
Port hawkeye to ROS 2 Humble

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,18 @@
+FROM ros:humble-ros-base
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    python3-colcon-common-extensions \
+    python3-rosdep \
+    ros-humble-pcl-ros \
+    ros-humble-pcl-conversions \
+    ros-humble-cv-bridge \
+    ros-humble-tf2-eigen \
+    ros-humble-tf2-geometry-msgs \
+    libyaml-cpp-dev \
+    libboost-all-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN echo "source /opt/ros/humble/setup.bash" >> /root/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "name": "hawkeye (ROS 2 Humble)",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "workspaceFolder": "/workspace/src/hawkeye",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/src/hawkeye,type=bind",
+  "postCreateCommand": "cd /workspace && rosdep update && rosdep install --from-paths src --ignore-src -r -y",
+  "postStartCommand": "source /opt/ros/humble/setup.bash",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools",
+        "ms-vscode.cmake-tools",
+        "twxs.cmake"
+      ],
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "C_Cpp.default.includePath": [
+          "/opt/ros/humble/include/**",
+          "${workspaceFolder}/include"
+        ]
+      }
+    }
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: Build
+
+on:
+  push:
+    branches: [develop, develop-ros2, main]
+  pull_request:
+    branches: [develop, develop-ros2, main]
+
+jobs:
+  build-ros1:
+    name: ROS 1 (Noetic)
+    runs-on: ubuntu-latest
+    if: github.base_ref == 'develop' || github.ref == 'refs/heads/develop' || github.base_ref == 'main' || github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t hawkeye-noetic -f .devcontainer/Dockerfile.noetic .devcontainer/ 2>/dev/null || docker build -t hawkeye-noetic .devcontainer/
+
+      - name: Build with catkin
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/workspace/src/hawkeye \
+            hawkeye-noetic \
+            bash -c "source /opt/ros/noetic/setup.bash && cd /workspace && catkin_make 2>&1"
+
+  build-ros2:
+    name: ROS 2 (Humble)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t hawkeye-humble .devcontainer/
+
+      - name: Build with colcon
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/workspace/src/hawkeye \
+            hawkeye-humble \
+            bash -c "
+              source /opt/ros/humble/setup.bash && \
+              cd /workspace && \
+              colcon build --symlink-install 2>&1
+            "

--- a/hawkeye/CMakeLists.txt
+++ b/hawkeye/CMakeLists.txt
@@ -1,46 +1,54 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.8)
 project(hawkeye)
 
 set(CMAKE_CXX_STANDARD 17)
 
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(visualization_msgs REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(tf2_eigen REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
+find_package(pcl_ros REQUIRED)
+find_package(pcl_conversions REQUIRED)
+find_package(cv_bridge REQUIRED)
 find_package(Boost REQUIRED)
 find_package(PCL REQUIRED)
-find_package(catkin REQUIRED)
 find_package(OpenCV REQUIRED)
 pkg_check_modules(YAML_CPP REQUIRED yaml-cpp)
-link_directories(${PCL_LIBRARY_DIRS})
-link_directories(${OpenCV_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-add_definitions(${OpenCV_DEFINITIONS})
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
+link_directories(${PCL_LIBRARY_DIRS})
+add_definitions(${PCL_DEFINITIONS})
+
+set(deps
+  rclcpp
   std_msgs
   nav_msgs
-  pcl_ros
   sensor_msgs
+  geometry_msgs
+  visualization_msgs
   tf2
   tf2_ros
   tf2_eigen
   tf2_geometry_msgs
+  pcl_ros
+  pcl_conversions
   cv_bridge
 )
 
-catkin_package(
-  INCLUDE_DIRS include
-  DEPENDS PCL
-  DEPENDS OpenCV
-)
-
 include_directories(include
-  ${catkin_INCLUDE_DIRS}
   ${PCL_INCLUDE_DIRS}
   ${OpenCV_INCLUDE_DIRS}
   ${YAML_CPP_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
 )
 
-set(srcs 
+set(srcs
   src/map/orthomap.cpp
   src/map/orthomap_read.cpp
   src/util/tf_messages.cpp
@@ -59,13 +67,12 @@ add_executable(hawkeye_rt
   ${hawkeye_srcs}
   src/hawkeye_rt/hawkeye_node.cpp
 )
+ament_target_dependencies(hawkeye_rt ${deps})
 target_link_libraries(hawkeye_rt
-  ${catkin_LIBRARIES}
   ${PCL_LIBRARIES}
   ${OpenCV_LIBRARIES}
   ${YAML_CPP_LIBRARIES}
 )
-add_dependencies(hawkeye_rt ${catkin_EXPORTED_TARGETS})
 
 # hawkeye_rt_ws
 add_executable(hawkeye_rt_ws
@@ -73,22 +80,26 @@ add_executable(hawkeye_rt_ws
   ${hawkeye_srcs}
   src/hawkeye_rt/hawkeye_ws_node.cpp
 )
+ament_target_dependencies(hawkeye_rt_ws ${deps})
 target_link_libraries(hawkeye_rt_ws
-  ${catkin_LIBRARIES}
   ${PCL_LIBRARIES}
   ${OpenCV_LIBRARIES}
   ${YAML_CPP_LIBRARIES}
 )
-add_dependencies(hawkeye_rt_ws ${catkin_EXPORTED_TARGETS})
 
 add_library(${PROJECT_NAME}_lib
   ${srcs}
   ${hawkeye_srcs}
 )
-
+ament_target_dependencies(${PROJECT_NAME}_lib ${deps})
 target_link_libraries(${PROJECT_NAME}_lib
-  ${catkin_LIBRARIES}
   ${PCL_LIBRARIES}
   ${OpenCV_LIBRARIES}
   ${YAML_CPP_LIBRARIES}
 )
+
+install(TARGETS hawkeye_rt hawkeye_rt_ws
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+ament_package()

--- a/hawkeye/include/hawkeye_base/base.hpp
+++ b/hawkeye/include/hawkeye_base/base.hpp
@@ -25,7 +25,8 @@
 
 #pragma once
 
-#include <visualization_msgs/MarkerArray.h>
+#include <visualization_msgs/msg/marker_array.hpp>
+#include <std_msgs/msg/header.hpp>
 
 #include "hawkeye_define.hpp"
 #include "hawkeye_base/histogram.hpp"
@@ -78,8 +79,8 @@ std::tuple<histogram_t, tf2::Vector3, tf2::Vector3> shiftCenter(const histogram_
                                                                 const tf2::Vector3& center, const tf2::Vector3& offset,
                                                                 double threshold_rate, bool edge_copy_shift = true);
 
-void setHistogramMarkers(visualization_msgs::MarkerArray& ma, const weighted_histogram_t& histogram,
-                         const tf2::Transform& odometry, const std_msgs::Header& header, bool as_array = false);
+void setHistogramMarkers(visualization_msgs::msg::MarkerArray& ma, const weighted_histogram_t& histogram,
+                         const tf2::Transform& odometry, const std_msgs::msg::Header& header, bool as_array = false);
 
 cv::Mat convertHistogram2CVU8C1(const cv::Mat& histogram);
 cv::Mat convertHistogram2CVU8C1(const weighted_histogram_t& histogram);

--- a/hawkeye/include/hawkeye_base/histogram.hpp
+++ b/hawkeye/include/hawkeye_base/histogram.hpp
@@ -29,7 +29,7 @@
 #include <tuple>
 
 #include <opencv2/opencv.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include "hawkeye_define.hpp"
 

--- a/hawkeye/include/hawkeye_base/node.hpp
+++ b/hawkeye/include/hawkeye_base/node.hpp
@@ -25,7 +25,8 @@
 
 #pragma once
 
-#include <visualization_msgs/MarkerArray.h>
+#include <visualization_msgs/msg/marker_array.hpp>
+#include <std_msgs/msg/header.hpp>
 
 #include "hawkeye_define.hpp"
 #include "hawkeye_base/histogram.hpp"
@@ -86,7 +87,8 @@ public:
   cv::Mat getSubmapImage() const;
   cv::Mat getWeightImage() const;
 
-  const visualization_msgs::MarkerArray& getHistogramMarkers(const std_msgs::Header& header, bool as_array = false);
+  const visualization_msgs::msg::MarkerArray& getHistogramMarkers(const std_msgs::msg::Header& header,
+                                                                  bool as_array = false);
 
 private:
   void adjustPCs();
@@ -111,7 +113,7 @@ private:
   double essential_time_;
   size_t counter_;
 
-  visualization_msgs::MarkerArray marker_array_;
+  visualization_msgs::msg::MarkerArray marker_array_;
 
   const Config config_;
   const double histogram_weight_;

--- a/hawkeye/include/map/orthomap.hpp
+++ b/hawkeye/include/map/orthomap.hpp
@@ -28,8 +28,9 @@
 #include <string>
 
 #include <opencv2/opencv.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#include <nav_msgs/OccupancyGrid.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <nav_msgs/msg/occupancy_grid.hpp>
+#include <std_msgs/msg/header.hpp>
 
 #include "hawkeye_define.hpp"
 
@@ -82,8 +83,8 @@ public:
 
   bool ckeckGridLatest(const tf2::Vector3& pos, size_t range) const;
 
-  const nav_msgs::OccupancyGrid& getGridAround(const std_msgs::Header& header, const tf2::Vector3& pos,
-                                               size_t range = 1);
+  const nav_msgs::msg::OccupancyGrid& getGridAround(const std_msgs::msg::Header& header, const tf2::Vector3& pos,
+                                                    size_t range = 1);
 
 private:
   inline uchar at(tf2::Vector3 pos) const
@@ -150,7 +151,7 @@ private:
   bool classify_emptiness_;
   struct
   {
-    nav_msgs::OccupancyGrid data_;
+    nav_msgs::msg::OccupancyGrid data_;
     std::optional<std::tuple<int, int, size_t>> last_info_;
   } og_map_;
 };

--- a/hawkeye/include/util/pose_stamped_helper.hpp
+++ b/hawkeye/include/util/pose_stamped_helper.hpp
@@ -29,21 +29,22 @@
 #include <vector>
 #include <map>
 
-#include <geometry_msgs/PoseStamped.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 namespace hawkeye
 {
 template <class _Ty>
-using TimeOrder_t = std::map<ros::Time, _Ty>;
+using TimeOrder_t = std::map<rclcpp::Time, _Ty>;
 
-inline bool comparePS(const geometry_msgs::PoseStamped& p1, const geometry_msgs::PoseStamped& p2)
+inline bool comparePS(const geometry_msgs::msg::PoseStamped& p1, const geometry_msgs::msg::PoseStamped& p2)
 {
-  return p1.header.stamp < p2.header.stamp;
+  return rclcpp::Time(p1.header.stamp) < rclcpp::Time(p2.header.stamp);
 }
-inline bool equalPS(const geometry_msgs::PoseStamped& p1, const geometry_msgs::PoseStamped& p2)
+inline bool equalPS(const geometry_msgs::msg::PoseStamped& p1, const geometry_msgs::msg::PoseStamped& p2)
 {
-  return p1.header.stamp == p2.header.stamp;
+  return rclcpp::Time(p1.header.stamp) == rclcpp::Time(p2.header.stamp);
 }
 
 enum class find_result
@@ -72,29 +73,29 @@ inline find_result operator|(const find_result l, const find_result r)
   return find_result(int(l) | int(r));
 }
 
-std::tuple<find_result, typename std::vector<geometry_msgs::PoseStamped>::const_iterator,
-           typename std::vector<geometry_msgs::PoseStamped>::const_iterator>
-findBoundWithResult(const std::vector<geometry_msgs::PoseStamped>& traj_csv, const ros::Time& stamp);
-std::tuple<find_result, typename TimeOrder_t<geometry_msgs::Pose>::const_iterator,
-           typename TimeOrder_t<geometry_msgs::Pose>::const_iterator>
-findBoundWithResult(const TimeOrder_t<geometry_msgs::Pose>& traj_csv, const ros::Time& stamp);
+std::tuple<find_result, typename std::vector<geometry_msgs::msg::PoseStamped>::const_iterator,
+           typename std::vector<geometry_msgs::msg::PoseStamped>::const_iterator>
+findBoundWithResult(const std::vector<geometry_msgs::msg::PoseStamped>& traj_csv, const rclcpp::Time& stamp);
+std::tuple<find_result, typename TimeOrder_t<geometry_msgs::msg::Pose>::const_iterator,
+           typename TimeOrder_t<geometry_msgs::msg::Pose>::const_iterator>
+findBoundWithResult(const TimeOrder_t<geometry_msgs::msg::Pose>& traj_csv, const rclcpp::Time& stamp);
 
-inline double getInterpolateRate(const ros::Time& target, const ros::Time& before, const ros::Time& after)
+inline double getInterpolateRate(const rclcpp::Time& target, const rclcpp::Time& before, const rclcpp::Time& after)
 {
-  double passed = (target - before).toNSec();
-  double range = (after - before).toNSec();
+  double passed = static_cast<double>((target - before).nanoseconds());
+  double range = static_cast<double>((after - before).nanoseconds());
   return passed / range;
 }
 
 tf2::Transform interpolatePose(const tf2::Transform& before, const tf2::Transform& after, double t);
-tf2::Transform interpolatePose(const geometry_msgs::Pose& before, const geometry_msgs::Pose& after, double t);
+tf2::Transform interpolatePose(const geometry_msgs::msg::Pose& before, const geometry_msgs::msg::Pose& after, double t);
 
-std::optional<tf2::Transform> findPose(const std::vector<geometry_msgs::PoseStamped>& traj_csv, size_t& prev,
-                                       const ros::Time& stamp);
+std::optional<tf2::Transform> findPose(const std::vector<geometry_msgs::msg::PoseStamped>& traj_csv, size_t& prev,
+                                       const rclcpp::Time& stamp);
 
-std::optional<tf2::Transform> findPoseInterpolated(const std::vector<geometry_msgs::PoseStamped>& traj_csv,
-                                                   const ros::Time& stamp);
-std::optional<tf2::Transform> findPoseInterpolated(const TimeOrder_t<geometry_msgs::PoseStamped>& traj_csv,
-                                                   const ros::Time& stamp);
+std::optional<tf2::Transform> findPoseInterpolated(const std::vector<geometry_msgs::msg::PoseStamped>& traj_csv,
+                                                   const rclcpp::Time& stamp);
+std::optional<tf2::Transform> findPoseInterpolated(const TimeOrder_t<geometry_msgs::msg::PoseStamped>& traj_csv,
+                                                   const rclcpp::Time& stamp);
 
 }  // namespace hawkeye

--- a/hawkeye/include/util/pose_synchronize.hpp
+++ b/hawkeye/include/util/pose_synchronize.hpp
@@ -25,12 +25,12 @@
 
 #pragma once
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include "hawkeye_define.hpp"
 #include "util/pose_stamped_helper.hpp"
 
-#include <sensor_msgs/NavSatFix.h>
+#include <sensor_msgs/msg/nav_sat_fix.hpp>
 
 namespace hawkeye
 {
@@ -40,9 +40,10 @@ public:
   using this_type = PoseInterpolationSubscriber;
 
   PoseInterpolationSubscriber(bool check_eagleye_error = false)
-    : check_eageye_error_{ check_eagleye_error }, check_eageye_error2_{ false } {};
+    : check_eageye_error_{ check_eagleye_error }, check_eageye_error2_{ false }
+    , eagleye_enabled_time_{ rclcpp::Time(0, 0, RCL_ROS_TIME) } {};
 
-  bool addPose(const geometry_msgs::PoseStamped& pose_stamped)
+  bool addPose(const geometry_msgs::msg::PoseStamped& pose_stamped)
   {
     if (check_eageye_error_ && pose_stamped.pose.position.x == 0 && pose_stamped.pose.position.y == 0 &&
         pose_stamped.pose.position.z == 0)
@@ -51,13 +52,13 @@ public:
     }
     if (check_eageye_error2_)
     {
-      if (eagleye_enabled_time_.is_zero())
+      if (eagleye_enabled_time_.nanoseconds() == 0)
       {
         return false;
       }
-      if (eagleye_enabled_time_ > pose_stamped.header.stamp)
+      if (eagleye_enabled_time_ > rclcpp::Time(pose_stamped.header.stamp))
       {
-        std::cout << pose_stamped.header.stamp.toNSec() << " is not valid" << std::endl;
+        std::cout << rclcpp::Time(pose_stamped.header.stamp).nanoseconds() << " is not valid" << std::endl;
         return false;
       }
     }
@@ -65,27 +66,31 @@ public:
     {
       return false;
     }
-    pose_map_.insert_or_assign(pose_stamped.header.stamp, pose_stamped.pose);
+    pose_map_.insert_or_assign(rclcpp::Time(pose_stamped.header.stamp), pose_stamped.pose);
     return true;
   }
 
-  void addPoseSubscriber(ros::NodeHandle& nh, const std::string& name, uint32_t queue_size,
+  void addPoseSubscriber(rclcpp::Node* node, const std::string& name, uint32_t queue_size,
                          const std::string& frame_name = "")
   {
-    pose_subsciber_ = nh.subscribe(name, queue_size, &this_type::callbackPose, this);
+    pose_subsciber_ = node->create_subscription<geometry_msgs::msg::PoseStamped>(
+        name, queue_size,
+        [this](const geometry_msgs::msg::PoseStamped::SharedPtr ptr) { addPose(*ptr); });
     pose_frame_ = frame_name;
   }
 
-  void addEagleyeCheckSubscriber(ros::NodeHandle& nh, const std::string& name, uint32_t queue_size)
+  void addEagleyeCheckSubscriber(rclcpp::Node* node, const std::string& name, uint32_t queue_size)
   {
     check_eageye_error2_ = true;
-    eagleye_check_subscriber_ = nh.subscribe(name, queue_size, &this_type::callbackChecker, this);
+    eagleye_check_subscriber_ = node->create_subscription<sensor_msgs::msg::NavSatFix>(
+        name, queue_size,
+        [this](const sensor_msgs::msg::NavSatFix::SharedPtr ptr) { callbackChecker(ptr); });
   }
 
 protected:
-  using interpolated_pose_iter = std::pair<TimeOrder_t<geometry_msgs::Pose>::const_iterator, tf2::Transform>;
+  using interpolated_pose_iter = std::pair<TimeOrder_t<geometry_msgs::msg::Pose>::const_iterator, tf2::Transform>;
 
-  interpolated_pose_iter findForStamp_NoCheck(const ros::Time& stamp) const
+  interpolated_pose_iter findForStamp_NoCheck(const rclcpp::Time& stamp) const
   {
     auto [result, before, after] = findBoundWithResult(pose_map_, stamp);
     tf2::Transform ret;
@@ -102,43 +107,38 @@ protected:
   }
 
 private:
-  void callbackPose(const geometry_msgs::PoseStamped::Ptr ptr)
+  void callbackChecker(const sensor_msgs::msg::NavSatFix::SharedPtr ptr)
   {
-    addPose(*ptr);
-  }
-
-  void callbackChecker(const sensor_msgs::NavSatFix::Ptr ptr)
-  {
-    if (eagleye_enabled_time_.is_zero() && check_eageye_error2_ && ptr->status.service == 0)
+    if (eagleye_enabled_time_.nanoseconds() == 0 && check_eageye_error2_ && ptr->status.service == 0)
     {
-      eagleye_enabled_time_ = ptr->header.stamp;
-      std::cout << "eagleye is valid after " << eagleye_enabled_time_.toNSec() << std::endl;
+      eagleye_enabled_time_ = rclcpp::Time(ptr->header.stamp);
+      std::cout << "eagleye is valid after " << eagleye_enabled_time_.nanoseconds() << std::endl;
     }
   }
 
 protected:
-  TimeOrder_t<geometry_msgs::Pose> pose_map_;
+  TimeOrder_t<geometry_msgs::msg::Pose> pose_map_;
 
 private:
   bool check_eageye_error_;
   bool check_eageye_error2_;
   std::string pose_frame_;
-  ros::Subscriber pose_subsciber_;
-  ros::Subscriber eagleye_check_subscriber_;
-  ros::Time eagleye_enabled_time_;
+  rclcpp::SubscriptionBase::SharedPtr pose_subsciber_;
+  rclcpp::SubscriptionBase::SharedPtr eagleye_check_subscriber_;
+  rclcpp::Time eagleye_enabled_time_;
 };
 
 // --- PoseSychronizer ---
-// synchronize geometry_msgs/PoseStamped and topic with header by inpterpolating poses and return tf2/Transform
+// synchronize geometry_msgs/PoseStamped and topic with header by interpolating poses and return tf2/Transform
 template <typename _Ty, bool return_ptr>
 class PoseSychronizerSub : public PoseInterpolationSubscriber
 {
 public:
   using this_type = PoseSychronizerSub;
-  using topic_ptr_type = typename _Ty::Ptr;
+  using topic_ptr_type = std::shared_ptr<_Ty>;
   using topic_raw_type = _Ty;
   using topic_return_type = std::conditional_t<return_ptr, topic_ptr_type, topic_raw_type>;
-  using return_tuple_type = std::tuple<tf2::Transform, topic_return_type, ros::Time>;
+  using return_tuple_type = std::tuple<tf2::Transform, topic_return_type, rclcpp::Time>;
 
   PoseSychronizerSub(bool check_eagleye_error = false) : PoseInterpolationSubscriber{ check_eagleye_error } {};
 
@@ -150,12 +150,12 @@ public:
 
   bool addTopic(const topic_return_type& topic)
   {
-    std_msgs::Header const* const header = getTopicHeaderPtr(topic);
+    std_msgs::msg::Header const* const header = getTopicHeaderPtr(topic);
     if (!topic_frame_.empty() && header->frame_id != topic_frame_)
     {
       return false;
     }
-    topic_map_.insert_or_assign(header->stamp, topic);
+    topic_map_.insert_or_assign(rclcpp::Time(header->stamp), topic);
     return true;
   }
   bool addTopicPtr(const topic_ptr_type& topic_ptr)
@@ -170,10 +170,12 @@ public:
     }
   }
 
-  void addTopicSubscriber(ros::NodeHandle& nh, const std::string& name, uint32_t queue_size,
+  void addTopicSubscriber(rclcpp::Node* node, const std::string& name, uint32_t queue_size,
                           const std::string& frame_name = "")
   {
-    topic_subsciber_ = nh.subscribe(name, queue_size, &this_type::callbackTopic, this);
+    topic_subsciber_ = node->create_subscription<topic_raw_type>(
+        name, queue_size,
+        [this](const topic_ptr_type ptr) { addTopicPtr(ptr); });
     topic_frame_ = frame_name;
   }
 
@@ -229,11 +231,11 @@ private:
   using const_topic_iter = typename TimeOrder_t<topic_return_type>::const_iterator;
   using mid_result_t = std::pair<interpolated_pose_iter, const_topic_iter>;
 
-  static const std_msgs::Header* const getTopicHeaderPtr(const topic_ptr_type& topic)
+  static const std_msgs::msg::Header* const getTopicHeaderPtr(const topic_ptr_type& topic)
   {
     return &(topic->header);
   }
-  static const std_msgs::Header* const getTopicHeaderPtr(const topic_raw_type& topic)
+  static const std_msgs::msg::Header* const getTopicHeaderPtr(const topic_raw_type& topic)
   {
     return &(topic.header);
   }
@@ -250,15 +252,10 @@ private:
     return { findForStamp_NoCheck(topic_it->first), topic_it };
   }
 
-  void callbackTopic(const topic_ptr_type ptr)
-  {
-    addTopicPtr(ptr);
-  }
-
 private:
   TimeOrder_t<topic_return_type> topic_map_;
   std::string topic_frame_;
-  ros::Subscriber topic_subsciber_;
+  rclcpp::SubscriptionBase::SharedPtr topic_subsciber_;
 };
 
 template <typename _Ty>
@@ -271,7 +268,7 @@ public:
 };
 
 template <typename _Ty>
-class PoseSychronizer<boost::shared_ptr<_Ty>> : public PoseSychronizerSub<_Ty, true>
+class PoseSychronizer<std::shared_ptr<_Ty>> : public PoseSychronizerSub<_Ty, true>
 {
 public:
   PoseSychronizer(bool check_eagleye_error = false) : PoseSychronizerSub<_Ty, true>{ check_eagleye_error }

--- a/hawkeye/include/util/tf_messages.hpp
+++ b/hawkeye/include/util/tf_messages.hpp
@@ -27,12 +27,12 @@
 
 #include <optional>
 
-#include <ros/ros.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/static_transform_broadcaster.h>
-#include <visualization_msgs/MarkerArray.h>
-#include <nav_msgs/Path.h>
+#include <visualization_msgs/msg/marker_array.hpp>
+#include <nav_msgs/msg/path.hpp>
 
 namespace hawkeye
 {
@@ -52,23 +52,21 @@ void tf2_print(Output_& out, const std::string& name, const tf2::Transform& tf)
 class TfTrajPublisher
 {
 public:
-  TfTrajPublisher(ros::NodeHandle& node) : node_{ node }
-  {
-  }
+  TfTrajPublisher(rclcpp::Node* node);
 
   bool remove(const std::string& frame_target);
   bool reset(const std::string& frame_target);
 
   bool addNewPublisher(const std::string& frame_target, const std::string& topic_name, const std::string& frame_base);
 
-  void broadcastStatic(const std::string& frame_target, const tf2::Transform& tf_tf2, const ros::Time& time,
+  void broadcastStatic(const std::string& frame_target, const tf2::Transform& tf_tf2, const rclcpp::Time& time,
                        const std::string& frame_base);
-  bool broadcast(const std::string& frame_target, const tf2::Transform& tf_tf2, const ros::Time& time);
+  bool broadcast(const std::string& frame_target, const tf2::Transform& tf_tf2, const rclcpp::Time& time);
 
 private:
-  ros::NodeHandle& node_;
+  rclcpp::Node* node_;
 
-  using traj_t = std::pair<ros::Publisher, nav_msgs::Path>;
+  using traj_t = std::pair<rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr, nav_msgs::msg::Path>;
   tf2_ros::TransformBroadcaster dynamic_broadcaster_;
   tf2_ros::StaticTransformBroadcaster static_broadcaster_;
   std::map<std::string, traj_t> markers_;

--- a/hawkeye/package.xml
+++ b/hawkeye/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>hawkeye</name>
   <version>1.0.0</version>
   <description>Hawkeye package</description>
@@ -7,18 +7,23 @@
 
   <license>BSD 3-Clause</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>roscpp</depend>
+  <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>nav_msgs</depend>
-  <depend>pcl_ros</depend>
   <depend>sensor_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>visualization_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
+  <depend>pcl_ros</depend>
+  <depend>pcl_conversions</depend>
+  <depend>cv_bridge</depend>
 
   <export>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/hawkeye/src/hawkeye_base/base.cpp
+++ b/hawkeye/src/hawkeye_base/base.cpp
@@ -422,8 +422,8 @@ cv::Mat convertHistogram2CVU8C1(const match_result_t& histogram)
   return convertHistogram2CVU8C1(hist);
 }
 
-void setHistogramMarkers(visualization_msgs::MarkerArray& ma, const weighted_histogram_t& histogram,
-                         const tf2::Transform& odometry, const std_msgs::Header& header, bool as_array)
+void setHistogramMarkers(visualization_msgs::msg::MarkerArray& ma, const weighted_histogram_t& histogram,
+                         const tf2::Transform& odometry, const std_msgs::msg::Header& header, bool as_array)
 {
   ma.markers.clear();
   auto& [image, scale] = histogram;
@@ -437,8 +437,8 @@ void setHistogramMarkers(visualization_msgs::MarkerArray& ma, const weighted_his
   }
   cv::Size size = image.size();
   auto f = [min_weight, max_weight, base_point = odometry.getOrigin(), size, scale = scale](double val, cv::Point at) {
-    geometry_msgs::Point point_out;
-    std_msgs::ColorRGBA color_out;
+    geometry_msgs::msg::Point point_out;
+    std_msgs::msg::ColorRGBA color_out;
     double rank = (val - min_weight) / (max_weight - min_weight);
     // rank *= rank;
     color_out.r = std::clamp(2 * rank, 0., 1.);
@@ -460,12 +460,12 @@ void setHistogramMarkers(visualization_msgs::MarkerArray& ma, const weighted_his
   {
     ma.markers.reserve(size.width * size.height);
 
-    visualization_msgs::Marker marker;
+    visualization_msgs::msg::Marker marker;
     {
       marker.header = header;
       marker.ns = "histogram";
-      marker.action = visualization_msgs::Marker::MODIFY;
-      marker.type = visualization_msgs::Marker::ARROW;
+      marker.action = visualization_msgs::msg::Marker::MODIFY;
+      marker.type = visualization_msgs::msg::Marker::ARROW;
 
       marker.scale.x = scale;
       marker.scale.y = scale;
@@ -493,8 +493,8 @@ void setHistogramMarkers(visualization_msgs::MarkerArray& ma, const weighted_his
     {
       marker.header = header;
       marker.ns = "histogram";
-      marker.action = visualization_msgs::Marker::MODIFY;
-      marker.type = visualization_msgs::Marker::POINTS;
+      marker.action = visualization_msgs::msg::Marker::MODIFY;
+      marker.type = visualization_msgs::msg::Marker::POINTS;
 
       marker.color.r = 0;
       marker.color.g = 1;

--- a/hawkeye/src/hawkeye_base/node.cpp
+++ b/hawkeye/src/hawkeye_base/node.cpp
@@ -329,8 +329,8 @@ cv::Mat Hawkeye<HawkeyeMode>::getWeightImage() const
 }
 
 template <typename HawkeyeMode>
-const visualization_msgs::MarkerArray& Hawkeye<HawkeyeMode>::getHistogramMarkers(const std_msgs::Header& header,
-                                                                                 bool as_array)
+const visualization_msgs::msg::MarkerArray& Hawkeye<HawkeyeMode>::getHistogramMarkers(
+    const std_msgs::msg::Header& header, bool as_array)
 {
   setHistogramMarkers(marker_array_, weighted_histogram_, histogram_center_, header, as_array);
   return marker_array_;

--- a/hawkeye/src/hawkeye_rt/hawkeye_node.cpp
+++ b/hawkeye/src/hawkeye_rt/hawkeye_node.cpp
@@ -23,13 +23,16 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #include <pcl/conversions.h>
 #include <pcl/common/transforms.h>
-#include <pcl_ros/point_cloud.h>
-#include <tf2_eigen/tf2_eigen.h>
+#include <pcl_conversions/pcl_conversions.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 #include <cv_bridge/cv_bridge.h>
-#include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <nav_msgs/msg/occupancy_grid.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+#include <sensor_msgs/msg/image.hpp>
 
 #include "hawkeye_define.hpp"
 #include "hawkeye_base/node.hpp"
@@ -49,13 +52,13 @@ double getYaw(const tf2::Transform& tf)
   return yaw;
 }
 
-class HawkeyeM4Node
+class HawkeyeM4Node : public rclcpp::Node
 {
 public:
   HawkeyeM4Node(const std::string& orthomap_filename, const std::string& config_filename,
                 const std::string& lidar_topic_name,
                 const hawkeye_base::HawkeyeConfig& config = hawkeye_base::HawkeyeConfig::defaultConfig())
-    : node_handle_{ "" }, counter_{ 0 }, pose_synchronizer_{ false }, times_{ 0 }, essential_times_{ 0 }
+    : rclcpp::Node("hawkeye_rt"), counter_{ 0 }, pose_synchronizer_{ false }, times_{ 0 }, essential_times_{ 0 }
   {
     Stopwatch sw;
 
@@ -66,25 +69,25 @@ public:
     map_.emplace(orthomap_filename);
 
     // setting ros publishers --------------------------------------------------
-    pose_synchronizer_.addPoseSubscriber(node_handle_, "/eagleye/pose", 100);
-    pose_synchronizer_.addEagleyeCheckSubscriber(node_handle_, "/eagleye/fix", 100);
-    pose_synchronizer_.addTopicSubscriber(node_handle_, lidar_topic_name, 4);
+    pose_synchronizer_.addPoseSubscriber(this, "/eagleye/pose", 100);
+    pose_synchronizer_.addEagleyeCheckSubscriber(this, "/eagleye/fix", 100);
+    pose_synchronizer_.addTopicSubscriber(this, lidar_topic_name, 4);
 
-    broadcaster_.emplace(node_handle_);
+    broadcaster_.emplace(this);
     broadcaster_->addNewPublisher("raw_tf", "raw_path", "local_map");
     broadcaster_->addNewPublisher("histogram_center", "histogram_center_path", "local_map");
     broadcaster_->addNewPublisher("estimated", "estimated_path", "local_map");
     broadcaster_->addNewPublisher("histogram_peak", "histogram_peak_path", "local_map");
     broadcaster_->addNewPublisher("match_peak", "match_peak_path", "local_map");
 
-    pc_publisher_ = node_handle_.advertise<sensor_msgs::PointCloud2>("point_cloud", 5, false);
-    map_publisher_ = node_handle_.advertise<nav_msgs::OccupancyGrid>("ortho_map", 1, false);
-    histogram_publisher_ = node_handle_.advertise<visualization_msgs::MarkerArray>("histogram", 5, false);
-    template_image_publisher_ = node_handle_.advertise<sensor_msgs::Image>("template_image", 5);
-    match_image_publisher_ = node_handle_.advertise<sensor_msgs::Image>("match_image", 5);
-    submap_image_publisher_ = node_handle_.advertise<sensor_msgs::Image>("submap_image", 5);
+    pc_publisher_ = create_publisher<sensor_msgs::msg::PointCloud2>("point_cloud", 5);
+    map_publisher_ = create_publisher<nav_msgs::msg::OccupancyGrid>("ortho_map", 1);
+    histogram_publisher_ = create_publisher<visualization_msgs::msg::MarkerArray>("histogram", 5);
+    template_image_publisher_ = create_publisher<sensor_msgs::msg::Image>("template_image", 5);
+    match_image_publisher_ = create_publisher<sensor_msgs::msg::Image>("match_image", 5);
+    submap_image_publisher_ = create_publisher<sensor_msgs::msg::Image>("submap_image", 5);
 
-    broadcaster_->broadcastStatic("local_map", map_->center(), ros::Time::now(), "map");
+    broadcaster_->broadcastStatic("local_map", map_->center(), this->now(), "map");
 
     // setting filter --------------------------------------------------
     hawkeye_.emplace(map_->getScale(), config);
@@ -119,10 +122,10 @@ public:
   void run(double rate = 10, bool small_overhead = false)
   {
     std::cout << "start" << std::endl;
-    ros::Rate r(rate);
-    while (ros::ok())
+    rclcpp::Rate r(rate);
+    while (rclcpp::ok())
     {
-      ros::spinOnce();
+      rclcpp::spin_some(shared_from_this());
       runOnce(small_overhead);
       r.sleep();
     }
@@ -138,8 +141,8 @@ public:
   }
 
 private:
-  void update(const sensor_msgs::PointCloud2::Ptr& ptr, const tf2::Transform& odometry, const ros::Time stamp,
-              bool small_overhead = false)
+  void update(const sensor_msgs::msg::PointCloud2::SharedPtr& ptr, const tf2::Transform& odometry,
+              const rclcpp::Time stamp, bool small_overhead = false)
   {
     Stopwatch sw, loop_sw;
     double essential_time = 0;
@@ -191,16 +194,15 @@ private:
         // publish ground point cloud --------------------------------------------------
         std::cout << "publish point cloud ... " << std::flush;
         sw.reset();
-        geometry_msgs::TransformStamped tf_gm;
+        geometry_msgs::msg::TransformStamped tf_gm;
         PC_t shift_pc;
-        sensor_msgs::PointCloud2 pcl_pc;
+        sensor_msgs::msg::PointCloud2 pcl_pc;
         tf2::convert(ans * hawkeye_->getLidarTf(), tf_gm.transform);
-        // tf_gm.transform.translation.z = 0;
         pcl::transformPointCloud(*ground, shift_pc, tf2::transformToEigen(tf_gm).matrix());
         pcl::toROSMsg(shift_pc, pcl_pc);
         pcl_pc.header = ptr->header;
         pcl_pc.header.frame_id = "local_map";
-        pc_publisher_.publish(pcl_pc);
+        pc_publisher_->publish(pcl_pc);
         sw.count();
         std::cout << "done in " << sw.get() << " ms" << std::endl;
       }
@@ -208,31 +210,29 @@ private:
         // publish images --------------------------------------------------
         std::cout << "publish images ... " << std::flush;
         sw.reset();
-        std_msgs::Header h;
+        std_msgs::msg::Header h;
         h.frame_id = "raw_tf";
-        h.seq = 0;
         h.stamp = stamp;
-        template_image_publisher_.publish(
-            cv_bridge::CvImage(h, sensor_msgs::image_encodings::TYPE_8UC1, hawkeye_->getTemplateImage()).toImageMsg());
-        match_image_publisher_.publish(
-            cv_bridge::CvImage(h, sensor_msgs::image_encodings::TYPE_8UC1, hawkeye_->getMatchImage()).toImageMsg());
-        submap_image_publisher_.publish(
-            cv_bridge::CvImage(h, sensor_msgs::image_encodings::TYPE_8UC1, hawkeye_->getSubmapImage()).toImageMsg());
+        template_image_publisher_->publish(
+            *cv_bridge::CvImage(h, sensor_msgs::image_encodings::TYPE_8UC1, hawkeye_->getTemplateImage()).toImageMsg());
+        match_image_publisher_->publish(
+            *cv_bridge::CvImage(h, sensor_msgs::image_encodings::TYPE_8UC1, hawkeye_->getMatchImage()).toImageMsg());
+        submap_image_publisher_->publish(
+            *cv_bridge::CvImage(h, sensor_msgs::image_encodings::TYPE_8UC1, hawkeye_->getSubmapImage()).toImageMsg());
         sw.count();
         std::cout << "done in " << sw.get() << " ms" << std::endl;
       }
     }
     {
-      std_msgs::Header h;
+      std_msgs::msg::Header h;
       h.frame_id = "local_map";
-      h.seq = 0;
       h.stamp = stamp;
       {
         // publish histogram --------------------------------------------------
         std::cout << "publish histogram ... " << std::flush;
         sw.reset();
 
-        histogram_publisher_.publish(hawkeye_->getHistogramMarkers(h));
+        histogram_publisher_->publish(hawkeye_->getHistogramMarkers(h));
 
         sw.count();
         std::cout << "done in " << sw.get() << " ms" << std::endl;
@@ -245,7 +245,7 @@ private:
         bool update_map = !map_->ckeckGridLatest(ans.getOrigin(), 1);
         if (update_map)
         {
-          map_publisher_.publish(map_->getGridAround(h, ans.getOrigin(), 1));
+          map_publisher_->publish(map_->getGridAround(h, ans.getOrigin(), 1));
         }
 
         sw.count();
@@ -265,7 +265,6 @@ private:
   }
 
 private:
-  ros::NodeHandle node_handle_;
   std::optional<OrthoMap> map_;
   std::optional<hawkeye_base::Hawkeye<hawkeye_base::Hawkeye_CopyShiftMode>> hawkeye_;
 
@@ -273,15 +272,15 @@ private:
 
   bool last_updated_;
 
-  PoseSychronizer<sensor_msgs::PointCloud2::Ptr> pose_synchronizer_;
+  PoseSychronizer<sensor_msgs::msg::PointCloud2::SharedPtr> pose_synchronizer_;
 
   std::optional<TfTrajPublisher> broadcaster_;
-  ros::Publisher pc_publisher_;
-  ros::Publisher map_publisher_;
-  ros::Publisher histogram_publisher_;
-  ros::Publisher template_image_publisher_;
-  ros::Publisher match_image_publisher_;
-  ros::Publisher submap_image_publisher_;
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pc_publisher_;
+  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr map_publisher_;
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr histogram_publisher_;
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr template_image_publisher_;
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr match_image_publisher_;
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr submap_image_publisher_;
 
   double times_;
   double essential_times_;
@@ -311,7 +310,7 @@ void exitArg(const std::string& message = "")
 
 int main(int argc, char** argv)
 {
-  ros::init(argc, argv, "hawkeye_rt");
+  rclcpp::init(argc, argv);
   char* orthomap_filename;
   char* config_filename;
   char* lidar_topic_name;
@@ -416,9 +415,10 @@ int main(int argc, char** argv)
   std::cout << "stop_threshold           : " << config.stop_threshold_ << std::endl;
   std::cout << "(-o) small_overhead      : " << std::boolalpha << small_overhead << std::noboolalpha << std::endl;
 
-  HawkeyeM4Node node(orthomap_filename, config_filename, lidar_topic_name, config);
+  auto node = std::make_shared<HawkeyeM4Node>(orthomap_filename, config_filename, lidar_topic_name, config);
 
-  node.run(10, small_overhead);
+  node->run(10, small_overhead);
 
+  rclcpp::shutdown();
   return 0;
 }

--- a/hawkeye/src/hawkeye_rt/hawkeye_ws_node.cpp
+++ b/hawkeye/src/hawkeye_rt/hawkeye_ws_node.cpp
@@ -23,13 +23,16 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #include <pcl/conversions.h>
 #include <pcl/common/transforms.h>
-#include <pcl_ros/point_cloud.h>
-#include <tf2_eigen/tf2_eigen.h>
+#include <pcl_conversions/pcl_conversions.h>
+#include <tf2_eigen/tf2_eigen.hpp>
 #include <cv_bridge/cv_bridge.h>
-#include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <nav_msgs/msg/occupancy_grid.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+#include <sensor_msgs/msg/image.hpp>
 
 #include "hawkeye_define.hpp"
 #include "hawkeye_base/node.hpp"
@@ -49,13 +52,13 @@ double getYaw(const tf2::Transform& tf)
   return yaw;
 }
 
-class HawkeyeWSM4Node
+class HawkeyeWSM4Node : public rclcpp::Node
 {
 public:
   HawkeyeWSM4Node(const std::string& orthomap_filename, const std::string& config_filename,
                   const std::string& lidar_topic_name,
                   const hawkeye_base::HawkeyeConfig& config = hawkeye_base::HawkeyeConfig::defaultConfig())
-    : node_handle_{ "" }, counter_{ 0 }, pose_synchronizer_{ false }, times_{ 0 }, essential_times_{ 0 }
+    : rclcpp::Node("hawkeye_rt_ws"), counter_{ 0 }, pose_synchronizer_{ false }, times_{ 0 }, essential_times_{ 0 }
   {
     Stopwatch sw;
 
@@ -66,26 +69,26 @@ public:
     map_.emplace(orthomap_filename);
 
     // setting ros publishers --------------------------------------------------
-    pose_synchronizer_.addPoseSubscriber(node_handle_, "/eagleye/pose", 100);
-    pose_synchronizer_.addEagleyeCheckSubscriber(node_handle_, "/eagleye/fix", 100);
-    pose_synchronizer_.addTopicSubscriber(node_handle_, lidar_topic_name, 4);
+    pose_synchronizer_.addPoseSubscriber(this, "/eagleye/pose", 100);
+    pose_synchronizer_.addEagleyeCheckSubscriber(this, "/eagleye/fix", 100);
+    pose_synchronizer_.addTopicSubscriber(this, lidar_topic_name, 4);
 
-    broadcaster_.emplace(node_handle_);
+    broadcaster_.emplace(this);
     broadcaster_->addNewPublisher("raw_tf", "raw_path", "local_map");
     broadcaster_->addNewPublisher("histogram_center", "histogram_center_path", "local_map");
     broadcaster_->addNewPublisher("estimated", "estimated_path", "local_map");
     broadcaster_->addNewPublisher("histogram_peak", "histogram_peak_path", "local_map");
     broadcaster_->addNewPublisher("match_peak", "match_peak_path", "local_map");
 
-    pc_publisher_ = node_handle_.advertise<sensor_msgs::PointCloud2>("point_cloud", 5, false);
-    map_publisher_ = node_handle_.advertise<nav_msgs::OccupancyGrid>("ortho_map", 1, false);
-    histogram_publisher_ = node_handle_.advertise<visualization_msgs::MarkerArray>("histogram", 5, false);
-    template_image_publisher_ = node_handle_.advertise<sensor_msgs::Image>("template_image", 5);
-    match_image_publisher_ = node_handle_.advertise<sensor_msgs::Image>("match_image", 5);
-    submap_image_publisher_ = node_handle_.advertise<sensor_msgs::Image>("submap_image", 5);
-    weight_image_publisher_ = node_handle_.advertise<sensor_msgs::Image>("weight_image", 5);
+    pc_publisher_ = create_publisher<sensor_msgs::msg::PointCloud2>("point_cloud", 5);
+    map_publisher_ = create_publisher<nav_msgs::msg::OccupancyGrid>("ortho_map", 1);
+    histogram_publisher_ = create_publisher<visualization_msgs::msg::MarkerArray>("histogram", 5);
+    template_image_publisher_ = create_publisher<sensor_msgs::msg::Image>("template_image", 5);
+    match_image_publisher_ = create_publisher<sensor_msgs::msg::Image>("match_image", 5);
+    submap_image_publisher_ = create_publisher<sensor_msgs::msg::Image>("submap_image", 5);
+    weight_image_publisher_ = create_publisher<sensor_msgs::msg::Image>("weight_image", 5);
 
-    broadcaster_->broadcastStatic("local_map", map_->center(), ros::Time::now(), "map");
+    broadcaster_->broadcastStatic("local_map", map_->center(), this->now(), "map");
 
     // setting filter --------------------------------------------------
     hawkeye_.emplace(map_->getScale(), config);
@@ -120,10 +123,10 @@ public:
   void run(double rate = 10, bool small_overhead = false)
   {
     std::cout << "start" << std::endl;
-    ros::Rate r(rate);
-    while (ros::ok())
+    rclcpp::Rate r(rate);
+    while (rclcpp::ok())
     {
-      ros::spinOnce();
+      rclcpp::spin_some(shared_from_this());
       runOnce(small_overhead);
       r.sleep();
     }
@@ -139,8 +142,8 @@ public:
   }
 
 private:
-  void update(const sensor_msgs::PointCloud2::Ptr& ptr, const tf2::Transform& odometry, const ros::Time stamp,
-              bool small_overhead = false)
+  void update(const sensor_msgs::msg::PointCloud2::SharedPtr& ptr, const tf2::Transform& odometry,
+              const rclcpp::Time stamp, bool small_overhead = false)
   {
     Stopwatch sw, loop_sw;
     double essential_time = 0;
@@ -191,16 +194,15 @@ private:
         // publish ground point cloud --------------------------------------------------
         std::cout << "publish point cloud ... " << std::flush;
         sw.reset();
-        geometry_msgs::TransformStamped tf_gm;
+        geometry_msgs::msg::TransformStamped tf_gm;
         PC_t shift_pc;
-        sensor_msgs::PointCloud2 pcl_pc;
+        sensor_msgs::msg::PointCloud2 pcl_pc;
         tf2::convert(ans * hawkeye_->getLidarTf(), tf_gm.transform);
-        // tf_gm.transform.translation.z = 0;
         pcl::transformPointCloud(*ground, shift_pc, tf2::transformToEigen(tf_gm).matrix());
         pcl::toROSMsg(shift_pc, pcl_pc);
         pcl_pc.header = ptr->header;
         pcl_pc.header.frame_id = "local_map";
-        pc_publisher_.publish(pcl_pc);
+        pc_publisher_->publish(pcl_pc);
         sw.count();
         std::cout << "done in " << sw.get() << " ms" << std::endl;
       }
@@ -208,33 +210,31 @@ private:
         // publish images --------------------------------------------------
         std::cout << "publish images ... " << std::flush;
         sw.reset();
-        std_msgs::Header h;
+        std_msgs::msg::Header h;
         h.frame_id = "raw_tf";
-        h.seq = 0;
         h.stamp = stamp;
-        template_image_publisher_.publish(
-            cv_bridge::CvImage(h, sensor_msgs::image_encodings::TYPE_8UC1, hawkeye_->getTemplateImage()).toImageMsg());
-        match_image_publisher_.publish(
-            cv_bridge::CvImage(h, sensor_msgs::image_encodings::TYPE_8UC1, hawkeye_->getMatchImage()).toImageMsg());
-        submap_image_publisher_.publish(
-            cv_bridge::CvImage(h, sensor_msgs::image_encodings::TYPE_8UC1, hawkeye_->getSubmapImage()).toImageMsg());
-        weight_image_publisher_.publish(
-            cv_bridge::CvImage(h, sensor_msgs::image_encodings::TYPE_8UC1, hawkeye_->getWeightImage()).toImageMsg());
+        template_image_publisher_->publish(
+            *cv_bridge::CvImage(h, sensor_msgs::image_encodings::TYPE_8UC1, hawkeye_->getTemplateImage()).toImageMsg());
+        match_image_publisher_->publish(
+            *cv_bridge::CvImage(h, sensor_msgs::image_encodings::TYPE_8UC1, hawkeye_->getMatchImage()).toImageMsg());
+        submap_image_publisher_->publish(
+            *cv_bridge::CvImage(h, sensor_msgs::image_encodings::TYPE_8UC1, hawkeye_->getSubmapImage()).toImageMsg());
+        weight_image_publisher_->publish(
+            *cv_bridge::CvImage(h, sensor_msgs::image_encodings::TYPE_8UC1, hawkeye_->getWeightImage()).toImageMsg());
         sw.count();
         std::cout << "done in " << sw.get() << " ms" << std::endl;
       }
     }
     {
-      std_msgs::Header h;
+      std_msgs::msg::Header h;
       h.frame_id = "local_map";
-      h.seq = 0;
       h.stamp = stamp;
       {
         // publish histogram --------------------------------------------------
         std::cout << "publish histogram ... " << std::flush;
         sw.reset();
 
-        histogram_publisher_.publish(hawkeye_->getHistogramMarkers(h));
+        histogram_publisher_->publish(hawkeye_->getHistogramMarkers(h));
 
         sw.count();
         std::cout << "done in " << sw.get() << " ms" << std::endl;
@@ -247,7 +247,7 @@ private:
         bool update_map = !map_->ckeckGridLatest(ans.getOrigin(), 1);
         if (update_map)
         {
-          map_publisher_.publish(map_->getGridAround(h, ans.getOrigin(), 1));
+          map_publisher_->publish(map_->getGridAround(h, ans.getOrigin(), 1));
         }
 
         sw.count();
@@ -267,7 +267,6 @@ private:
   }
 
 private:
-  ros::NodeHandle node_handle_;
   std::optional<OrthoMap> map_;
   std::optional<hawkeye_base::Hawkeye<hawkeye_base::Hawkeye_WeightedShiftMode>> hawkeye_;
 
@@ -275,21 +274,19 @@ private:
 
   bool last_updated_;
 
-  PoseSychronizer<sensor_msgs::PointCloud2::Ptr> pose_synchronizer_;
+  PoseSychronizer<sensor_msgs::msg::PointCloud2::SharedPtr> pose_synchronizer_;
 
   std::optional<TfTrajPublisher> broadcaster_;
-  ros::Publisher pc_publisher_;
-  ros::Publisher map_publisher_;
-  ros::Publisher histogram_publisher_;
-  ros::Publisher template_image_publisher_;
-  ros::Publisher match_image_publisher_;
-  ros::Publisher submap_image_publisher_;
-  ros::Publisher weight_image_publisher_;
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pc_publisher_;
+  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr map_publisher_;
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr histogram_publisher_;
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr template_image_publisher_;
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr match_image_publisher_;
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr submap_image_publisher_;
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr weight_image_publisher_;
 
   double times_;
   double essential_times_;
-
-  size_t shift_count;
 };
 
 void exitArg(const std::string& message = "")
@@ -315,7 +312,7 @@ void exitArg(const std::string& message = "")
 
 int main(int argc, char** argv)
 {
-  ros::init(argc, argv, "hawkeye_rt_ws");
+  rclcpp::init(argc, argv);
   char* orthomap_filename;
   char* config_filename;
   char* lidar_topic_name;
@@ -414,9 +411,10 @@ int main(int argc, char** argv)
   std::cout << "stop_threshold           : " << config.stop_threshold_ << std::endl;
   std::cout << "(-o) small_overhead      : " << std::boolalpha << small_overhead << std::noboolalpha << std::endl;
 
-  HawkeyeWSM4Node node(orthomap_filename, config_filename, lidar_topic_name, config);
+  auto node = std::make_shared<HawkeyeWSM4Node>(orthomap_filename, config_filename, lidar_topic_name, config);
 
-  node.run(10, small_overhead);
+  node->run(10, small_overhead);
 
+  rclcpp::shutdown();
   return 0;
 }

--- a/hawkeye/src/map/orthomap.cpp
+++ b/hawkeye/src/map/orthomap.cpp
@@ -101,8 +101,8 @@ bool OrthoMap::ckeckGridLatest(const tf2::Vector3& pos, size_t range) const
   return false;
 }
 
-const nav_msgs::OccupancyGrid& OrthoMap::getGridAround(const std_msgs::Header& header, const tf2::Vector3& pos,
-                                                       size_t range)
+const nav_msgs::msg::OccupancyGrid& OrthoMap::getGridAround(const std_msgs::msg::Header& header,
+                                                            const tf2::Vector3& pos, size_t range)
 {
   og_map_.data_.header = header;
   og_map_.data_.info.origin.position.z = pos.z();

--- a/hawkeye/src/map/orthomap_read.cpp
+++ b/hawkeye/src/map/orthomap_read.cpp
@@ -27,8 +27,11 @@
 #include "util/error.hpp"
 #include "util/timer.hpp"
 
-#include <boost/filesystem.hpp>
-#include <tf2_eigen/tf2_eigen.h>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <iomanip>
+#include <tf2_eigen/tf2_eigen.hpp>
 
 template <typename T>
 void getFileElements(std::ifstream& ifs, const std::string& filename, T&& ref)
@@ -133,7 +136,7 @@ OrthoMap::OrthoMap(const std::string& orthomap_filename) : orthomap_filename_{ o
       }
     }
     {
-      auto filename_length = boost::filesystem::path(orthomap_filename_).filename().string().size();
+      auto filename_length = std::filesystem::path(orthomap_filename_).filename().string().size();
       prefix = orthomap_filename_.substr(0, orthomap_filename_.size() - filename_length) + prefix;
     }
   }

--- a/hawkeye/src/util/pose_stamped_helper.cpp
+++ b/hawkeye/src/util/pose_stamped_helper.cpp
@@ -59,20 +59,20 @@ inline find_result checkResult(const Iter_& bg, const Iter_& ed, const Iter_& lb
   }
 }
 
-std::tuple<find_result, typename std::vector<geometry_msgs::PoseStamped>::const_iterator,
-           typename std::vector<geometry_msgs::PoseStamped>::const_iterator>
-findBoundWithResult(const std::vector<geometry_msgs::PoseStamped>& traj_csv, const ros::Time& stamp)
+std::tuple<find_result, typename std::vector<geometry_msgs::msg::PoseStamped>::const_iterator,
+           typename std::vector<geometry_msgs::msg::PoseStamped>::const_iterator>
+findBoundWithResult(const std::vector<geometry_msgs::msg::PoseStamped>& traj_csv, const rclcpp::Time& stamp)
 {
-  geometry_msgs::PoseStamped tmp;
+  geometry_msgs::msg::PoseStamped tmp;
   tmp.header.stamp = stamp;
   auto lb = std::lower_bound(traj_csv.begin(), traj_csv.end(), tmp, comparePS);
   auto ub = std::upper_bound(traj_csv.begin(), traj_csv.end(), tmp, comparePS);
   find_result result = checkResult(traj_csv.cbegin(), traj_csv.cend(), lb, ub);
   return { result, lb, ub };
 }
-std::tuple<find_result, typename TimeOrder_t<geometry_msgs::Pose>::const_iterator,
-           typename TimeOrder_t<geometry_msgs::Pose>::const_iterator>
-findBoundWithResult(const TimeOrder_t<geometry_msgs::Pose>& traj_csv, const ros::Time& stamp)
+std::tuple<find_result, typename TimeOrder_t<geometry_msgs::msg::Pose>::const_iterator,
+           typename TimeOrder_t<geometry_msgs::msg::Pose>::const_iterator>
+findBoundWithResult(const TimeOrder_t<geometry_msgs::msg::Pose>& traj_csv, const rclcpp::Time& stamp)
 {
   auto lb = traj_csv.lower_bound(stamp);
   auto ub = traj_csv.upper_bound(stamp);
@@ -88,7 +88,7 @@ tf2::Transform interpolatePose(const tf2::Transform& before, const tf2::Transfor
   return pose;
 }
 
-tf2::Transform interpolatePose(const geometry_msgs::Pose& before, const geometry_msgs::Pose& after, double t)
+tf2::Transform interpolatePose(const geometry_msgs::msg::Pose& before, const geometry_msgs::msg::Pose& after, double t)
 {
   tf2::Transform before_tf, after_tf;
   tf2::convert(before, before_tf);
@@ -96,8 +96,8 @@ tf2::Transform interpolatePose(const geometry_msgs::Pose& before, const geometry
   return interpolatePose(before_tf, after_tf, t);
 }
 
-std::optional<tf2::Transform> findPoseInterpolated(const std::vector<geometry_msgs::PoseStamped>& traj_csv,
-                                                   const ros::Time& stamp)
+std::optional<tf2::Transform> findPoseInterpolated(const std::vector<geometry_msgs::msg::PoseStamped>& traj_csv,
+                                                   const rclcpp::Time& stamp)
 {
   auto [result, lb, ub] = findBoundWithResult(traj_csv, stamp);
   if ((result & find_result::FOUND) != find_result::NONE)
@@ -109,12 +109,13 @@ std::optional<tf2::Transform> findPoseInterpolated(const std::vector<geometry_ms
   else if (result == find_result::INTERPOLATABLE)
   {
     lb--;
-    return interpolatePose(lb->pose, ub->pose, getInterpolateRate(stamp, lb->header.stamp, ub->header.stamp));
+    return interpolatePose(lb->pose, ub->pose,
+                           getInterpolateRate(stamp, rclcpp::Time(lb->header.stamp), rclcpp::Time(ub->header.stamp)));
   }
   return std::nullopt;
 }
-std::optional<tf2::Transform> findPoseInterpolated(const TimeOrder_t<geometry_msgs::Pose>& traj_csv,
-                                                   const ros::Time& stamp)
+std::optional<tf2::Transform> findPoseInterpolated(const TimeOrder_t<geometry_msgs::msg::Pose>& traj_csv,
+                                                   const rclcpp::Time& stamp)
 {
   auto [result, lb, ub] = findBoundWithResult(traj_csv, stamp);
   if ((result & find_result::FOUND) != find_result::NONE)
@@ -131,11 +132,11 @@ std::optional<tf2::Transform> findPoseInterpolated(const TimeOrder_t<geometry_ms
   return std::nullopt;
 }
 
-std::optional<tf2::Transform> findPose(const std::vector<geometry_msgs::PoseStamped>& traj_csv, size_t& prev,
-                                       const ros::Time& stamp)
+std::optional<tf2::Transform> findPose(const std::vector<geometry_msgs::msg::PoseStamped>& traj_csv, size_t& prev,
+                                       const rclcpp::Time& stamp)
 {
   size_t id;
-  if (traj_csv[prev + 1].header.stamp == stamp)
+  if (rclcpp::Time(traj_csv[prev + 1].header.stamp) == stamp)
   {
     id = prev + 1;
     prev = id;
@@ -145,7 +146,7 @@ std::optional<tf2::Transform> findPose(const std::vector<geometry_msgs::PoseStam
     size_t l = prev, u = traj_csv.size();
     while (u - l > 1)
     {
-      auto& s = traj_csv[l + (u - l - 1) / 2].header.stamp;
+      rclcpp::Time s(traj_csv[l + (u - l - 1) / 2].header.stamp);
       if (s == stamp)
       {
         break;
@@ -165,7 +166,7 @@ std::optional<tf2::Transform> findPose(const std::vector<geometry_msgs::PoseStam
     }
     id = l + (u - l - 1) / 2;
     prev = id;
-    if (traj_csv[id].header.stamp != stamp)
+    if (rclcpp::Time(traj_csv[id].header.stamp) != stamp)
     {
       return std::nullopt;
     }

--- a/hawkeye/src/util/tf_messages.cpp
+++ b/hawkeye/src/util/tf_messages.cpp
@@ -27,6 +27,11 @@
 
 namespace hawkeye
 {
+TfTrajPublisher::TfTrajPublisher(rclcpp::Node* node)
+  : node_{ node }, dynamic_broadcaster_{ node }, static_broadcaster_{ node }
+{
+}
+
 bool TfTrajPublisher::addNewPublisher(const std::string& frame_target, const std::string& topic_name,
                                       const std::string& frame_base)
 {
@@ -34,10 +39,10 @@ bool TfTrajPublisher::addNewPublisher(const std::string& frame_target, const std
   {
     return false;
   }
-  auto [iter, b] =
-      markers_.insert(std::make_pair(frame_target, traj_t{ node_.advertise<nav_msgs::Path>(topic_name, 1, true), {} }));
-  auto& path = iter->second.second;
+  nav_msgs::msg::Path path;
   path.header.frame_id = frame_base;
+  auto pub = node_->create_publisher<nav_msgs::msg::Path>(topic_name, rclcpp::QoS(1).transient_local());
+  auto [iter, b] = markers_.insert(std::make_pair(frame_target, traj_t{ pub, path }));
   std::cout << std::quoted(frame_target) << "( from " << std::quoted(frame_base) << " ) has been added." << std::endl;
   return true;
 }
@@ -60,12 +65,11 @@ bool TfTrajPublisher::reset(const std::string& frame_target)
 }
 
 void TfTrajPublisher::broadcastStatic(const std::string& frame_target, const tf2::Transform& tf_tf2,
-                                      const ros::Time& time, const std::string& frame_base)
+                                      const rclcpp::Time& time, const std::string& frame_base)
 {
-  geometry_msgs::TransformStamped tf_gm;
+  geometry_msgs::msg::TransformStamped tf_gm;
   tf2::convert(tf_tf2, tf_gm.transform);
   tf_gm.header.stamp = time;
-  tf_gm.header.seq = 0;
   tf_gm.header.frame_id = frame_base;
   tf_gm.child_frame_id = frame_target;
   static_broadcaster_.sendTransform(tf_gm);
@@ -73,7 +77,8 @@ void TfTrajPublisher::broadcastStatic(const std::string& frame_target, const tf2
             << " has been broadcasted." << std::endl;
 }
 
-bool TfTrajPublisher::broadcast(const std::string& frame_target, const tf2::Transform& tf_tf2, const ros::Time& time)
+bool TfTrajPublisher::broadcast(const std::string& frame_target, const tf2::Transform& tf_tf2,
+                                const rclcpp::Time& time)
 {
   auto iter = markers_.find(frame_target);
   if (iter == markers_.end())
@@ -81,15 +86,14 @@ bool TfTrajPublisher::broadcast(const std::string& frame_target, const tf2::Tran
     std::cout << std::quoted(frame_target) << " cannot be broadcasted." << std::endl;
     return false;
   }
-  geometry_msgs::TransformStamped tf_gm;
+  geometry_msgs::msg::TransformStamped tf_gm;
   tf2::convert(tf_tf2, tf_gm.transform);
   tf_gm.header.stamp = time;
-  tf_gm.header.seq = 0;
   tf_gm.header.frame_id = iter->second.second.header.frame_id;
   tf_gm.child_frame_id = frame_target;
   dynamic_broadcaster_.sendTransform(tf_gm);
 
-  geometry_msgs::PoseStamped pose;
+  geometry_msgs::msg::PoseStamped pose;
   pose.pose.position.x = tf_gm.transform.translation.x;
   pose.pose.position.y = tf_gm.transform.translation.y;
   pose.pose.position.z = tf_gm.transform.translation.z;
@@ -98,7 +102,7 @@ bool TfTrajPublisher::broadcast(const std::string& frame_target, const tf2::Tran
   auto& path = iter->second.second;
   path.poses.push_back(pose);
   path.header = tf_gm.header;
-  iter->second.first.publish(path);
+  iter->second.first->publish(path);
   std::cout << std::quoted(frame_target) << " has been broadcasted." << std::endl;
   return true;
 }

--- a/orthomap_viewer/CMakeLists.txt
+++ b/orthomap_viewer/CMakeLists.txt
@@ -1,29 +1,26 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.8)
 project(orthomap_viewer)
 
 set(CMAKE_CXX_STANDARD 17)
 
-find_package(Boost REQUIRED)
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(nav_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(pcl_conversions REQUIRED)
 find_package(PCL REQUIRED)
-find_package(catkin REQUIRED)
 find_package(OpenCV REQUIRED)
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
+set(deps
+  rclcpp
   std_msgs
   nav_msgs
-  pcl_ros
   sensor_msgs
+  pcl_conversions
 )
 
-catkin_package(
-  #INCLUDE_DIRS include
-  DEPENDS PCL
-  DEPENDS OpenCV
-)
-
-include_directories(include
-  ${catkin_INCLUDE_DIRS}
+include_directories(
   ${PCL_INCLUDE_DIRS}
   ${OpenCV_INCLUDE_DIRS}
 )
@@ -31,9 +28,14 @@ include_directories(include
 add_executable(orthomap_viewer
   src/orthomap_viewer.cpp
 )
+ament_target_dependencies(orthomap_viewer ${deps})
 target_link_libraries(orthomap_viewer
-  ${catkin_LIBRARIES}
+  ${PCL_LIBRARIES}
   ${OpenCV_LIBRARIES}
 )
 
-add_dependencies(orthomap_viewer ${catkin_EXPORTED_TARGETS})
+install(TARGETS orthomap_viewer
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+ament_package()

--- a/orthomap_viewer/package.xml
+++ b/orthomap_viewer/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>orthomap_viewer</name>
   <version>1.0.0</version>
   <description>The orthomap_viewer package</description>
@@ -7,14 +7,16 @@
 
   <license>BSD 3-Clause</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>roscpp</depend>
+  <depend>rclcpp</depend>
   <depend>std_msgs</depend>
   <depend>nav_msgs</depend>
-  <depend>pcl_ros</depend>
   <depend>sensor_msgs</depend>
+  <depend>pcl_ros</depend>
+  <depend>pcl_conversions</depend>
 
   <export>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/orthomap_viewer/src/orthomap_viewer.cpp
+++ b/orthomap_viewer/src/orthomap_viewer.cpp
@@ -23,11 +23,12 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <ros/ros.h>
-#include <nav_msgs/OccupancyGrid.h>
-#include <pcl_ros/point_cloud.h>
+#include <rclcpp/rclcpp.hpp>
+#include <nav_msgs/msg/occupancy_grid.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <pcl_conversions/pcl_conversions.h>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 #include <opencv2/opencv.hpp>
 #include <pcl/io/pcd_io.h>
 
@@ -67,14 +68,12 @@ void getFileElements(std::ifstream& ifs, const std::string& filename, T&& ref)
   }
 }
 
-std::optional<nav_msgs::OccupancyGrid> draw_one(const std::string& topic_name, const std::string& tif_name, int seq);
-
 int main(int argc, char** argv)
 {
-  ros::init(argc, argv, "orthomap_view");
+  rclcpp::init(argc, argv);
   std::string input_file;
   std::string topic_name = "ortho_map";
-  bool topic_name_param;
+  bool topic_name_param = false;
   std::optional<std::string> pcd_name;
   std::optional<std::string> frame_name;
   if (argc < 2)
@@ -185,7 +184,7 @@ int main(int argc, char** argv)
     if (scaled)
     {
       getFileElements(ifs, input_file, threshold_min);
-      getFileElements(ifs, input_file, threshold_min);
+      getFileElements(ifs, input_file, threshold_max);
       ifs >> std::boolalpha;
       getFileElements(ifs, input_file, classify_emptiness);
       ifs >> std::noboolalpha;
@@ -201,7 +200,7 @@ int main(int argc, char** argv)
       {
         v.push_back(buf);
       }
-      if (v.size() != div_x * div_y)
+      if (v.size() != static_cast<size_t>(div_x * div_y))
       {
         exitBadFile(input_file, " (" + std::to_string(v.size()) + ")");
       }
@@ -219,7 +218,7 @@ int main(int argc, char** argv)
       }
     }
     {
-      auto filename_length = boost::filesystem::path(input_file).filename().string().size();
+      auto filename_length = std::filesystem::path(input_file).filename().string().size();
       prefix = input_file.substr(0, input_file.size() - filename_length) + prefix;
     }
   }
@@ -237,9 +236,10 @@ int main(int argc, char** argv)
   SHOW_PARAM(num_images);
   SHOW_PARAM2(classify_emptiness, std::boolalpha << classify_emptiness << std::noboolalpha);
 
-  ros::NodeHandle n("~");
-  ros::Publisher lane_publisher = n.advertise<nav_msgs::OccupancyGrid>("ortho_images", 1, true);
-  nav_msgs::OccupancyGrid grid;
+  auto node = std::make_shared<rclcpp::Node>("orthomap_viewer");
+  auto lane_publisher = node->create_publisher<nav_msgs::msg::OccupancyGrid>(
+      "ortho_images", rclcpp::QoS(1).transient_local());
+  nav_msgs::msg::OccupancyGrid grid;
 
   grid.info.width = width * div_x;
   grid.info.height = height * div_y;
@@ -304,11 +304,12 @@ int main(int argc, char** argv)
     }
     std::cout << " success." << std::endl;
   }
-  lane_publisher.publish(grid);
-  pcl::PointCloud<pcl::PointXYZI> pc;
-  ros::Publisher pc_pub;
+  lane_publisher->publish(grid);
+
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pc_pub;
   if (pcd_name)
   {
+    pcl::PointCloud<pcl::PointXYZI> pc;
     if (pcl::io::loadPCDFile(*pcd_name, pc) < 0)
     {
       std::cerr << "\033[1;31mError: Could not open " << *pcd_name << " as pcl::PointCloud<pcl::PointXYZI> \033[0m"
@@ -319,13 +320,19 @@ int main(int argc, char** argv)
     {
       p.z = 0.000001;
     }
-    pc_pub = n.advertise<pcl::PointCloud<pcl::PointXYZI>>("pcd_points", 1, true);
-    pc.header.frame_id = *frame_name;
-    pc_pub.publish(pc);
+    pc_pub = node->create_publisher<sensor_msgs::msg::PointCloud2>(
+        "pcd_points", rclcpp::QoS(1).transient_local());
+    sensor_msgs::msg::PointCloud2 pc_msg;
+    pcl::toROSMsg(pc, pc_msg);
+    pc_msg.header.frame_id = *frame_name;
+    pc_msg.header.stamp = node->now();
+    pc_pub->publish(pc_msg);
     std::cout << "publish point cloud" << std::endl;
   }
   std::cout << "finish and spin" << std::endl;
-  ros::spin();
+  rclcpp::spin(node);
   std::cout << std::endl;
+
+  rclcpp::shutdown();
   return 0;
 }


### PR DESCRIPTION
## Summary

- ビルドシステム: `catkin` → `ament_cmake`（`package.xml` format 3）
- ミドルウェア: `roscpp` / `ros::NodeHandle` → `rclcpp` / `rclcpp::Node`
- メッセージ型: `nav_msgs::Path` 等 → `nav_msgs::msg::Path` 等（全パッケージ）
- 時刻: `ros::Time` → `rclcpp::Time`、`ros::Rate` → `rclcpp::Rate`
- スマートポインタ: `boost::shared_ptr` → `std::shared_ptr`
- ヘッダ: `tf2_geometry_msgs.h` → `.hpp`、`tf2_eigen.h` → `.hpp`
- PCL: `pcl_ros/point_cloud.h` → `pcl_conversions/pcl_conversions.h`
- `boost::filesystem` → `std::filesystem`（C++17）
- `header.seq` 削除（ROS2非対応）
- `HawkeyeM4Node` / `HawkeyeWSM4Node` が `rclcpp::Node` を継承するように変更
- `TfTrajPublisher` / `PoseSychronizer` を rclcpp API に移行
- devcontainer（ROS 2 Humble）と GitHub Actions CI を追加

## 確認済み

Docker（ROS 2 Humble）上で `colcon build` が警告のみ・エラーなしで完了。