### PR TITLE
Add ROS 2 launch files

### DIFF
--- a/hawkeye/CMakeLists.txt
+++ b/hawkeye/CMakeLists.txt
@@ -102,4 +102,8 @@ install(TARGETS hawkeye_rt hawkeye_rt_ws
   DESTINATION lib/${PROJECT_NAME}
 )
 
+install(DIRECTORY launch config rviz
+  DESTINATION share/${PROJECT_NAME}
+)
+
 ament_package()

--- a/hawkeye/launch/hawkeye_rt.launch.py
+++ b/hawkeye/launch/hawkeye_rt.launch.py
@@ -1,0 +1,63 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IfCondition, UnlessCondition
+from launch.substitutions import LaunchConfiguration, FindExecutable, PathJoinSubstitution
+from launch.substitutions import PythonExpression
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    pkg = FindPackageShare("hawkeye")
+
+    ortho_map = LaunchConfiguration("ortho_map")
+    config = LaunchConfiguration("config")
+    lidar_topic_name = LaunchConfiguration("lidar_topic_name")
+    extra_args = LaunchConfiguration("extra_args")
+    ws_mode = LaunchConfiguration("ws_mode")
+    use_rviz = LaunchConfiguration("use_rviz")
+    rviz_info = LaunchConfiguration("rviz_info")
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument("ortho_map"),
+            DeclareLaunchArgument(
+                "config",
+                default_value=PathJoinSubstitution([pkg, "config", "hawkeye.yaml"]),
+            ),
+            DeclareLaunchArgument("lidar_topic_name", default_value="pointcloud_raw"),
+            DeclareLaunchArgument("extra_args", default_value=""),
+            DeclareLaunchArgument("ws_mode", default_value="false"),
+            DeclareLaunchArgument("use_rviz", default_value="true"),
+            DeclareLaunchArgument(
+                "rviz_info",
+                default_value=PathJoinSubstitution([pkg, "rviz", "hawkeye.rviz"]),
+            ),
+            # hawkeye_rt (CopyShiftMode)
+            Node(
+                package="hawkeye",
+                executable="hawkeye_rt",
+                name="hawkeye_rt",
+                arguments=[ortho_map, config, lidar_topic_name],
+                output="screen",
+                condition=UnlessCondition(ws_mode),
+            ),
+            # hawkeye_rt_ws (WeightedShiftMode)
+            Node(
+                package="hawkeye",
+                executable="hawkeye_rt_ws",
+                name="hawkeye_rt_ws",
+                arguments=[ortho_map, config, lidar_topic_name],
+                output="screen",
+                condition=IfCondition(ws_mode),
+            ),
+            # rviz2
+            Node(
+                package="rviz2",
+                executable="rviz2",
+                name="hawkeye_rviz",
+                arguments=["-d", rviz_info],
+                output="log",
+                condition=IfCondition(use_rviz),
+            ),
+        ]
+    )

--- a/hawkeye/launch/sample_single.launch.py
+++ b/hawkeye/launch/sample_single.launch.py
@@ -1,0 +1,43 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    pkg = FindPackageShare("hawkeye")
+
+    sample_dir = LaunchConfiguration("sample_dir")
+    lidar_topic_name = LaunchConfiguration("lidar_topic_name")
+    extra_args = LaunchConfiguration("extra_args")
+    ws_mode = LaunchConfiguration("ws_mode")
+    use_rviz = LaunchConfiguration("use_rviz")
+
+    ortho_map = PathJoinSubstitution([sample_dir, "map", "ortho_image", "_orthomap"])
+    config = PathJoinSubstitution([sample_dir, "config", "hawkeye.yaml"])
+    rviz_info = PathJoinSubstitution([pkg, "rviz", "hawkeye.rviz"])
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument("sample_dir", default_value=""),
+            DeclareLaunchArgument("lidar_topic_name", default_value="pointcloud_raw"),
+            DeclareLaunchArgument("extra_args", default_value=""),
+            DeclareLaunchArgument("ws_mode", default_value="false"),
+            DeclareLaunchArgument("use_rviz", default_value="true"),
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(
+                    PathJoinSubstitution([pkg, "launch", "hawkeye_rt.launch.py"])
+                ),
+                launch_arguments={
+                    "ortho_map": ortho_map,
+                    "config": config,
+                    "lidar_topic_name": lidar_topic_name,
+                    "extra_args": extra_args,
+                    "use_rviz": use_rviz,
+                    "rviz_info": rviz_info,
+                    "ws_mode": ws_mode,
+                }.items(),
+            ),
+        ]
+    )


### PR DESCRIPTION
## Summary

- `hawkeye_rt.launch.py` — `hawkeye_rt.launch` の ROS2 版（`hawkeye_rt` / `hawkeye_rt_ws` / `rviz2` を起動）
- `sample_single.launch.py` — `sample_single.launch` の ROS2 版（sample_dir からパスを解決して `hawkeye_rt.launch.py` をインクルード）
- `CMakeLists.txt` に `launch` / `config` / `rviz` のインストール設定を追加

## 使い方

```bash
ros2 launch hawkeye hawkeye_rt.launch.py ortho_map:=/path/to/_orthomap lidar_topic_name:=/lidar/points

# sample_dir を使う場合
ros2 launch hawkeye sample_single.launch.py sample_dir:=/path/to/sample
```

## 確認済み

`colcon build` 成功。